### PR TITLE
Oom fix

### DIFF
--- a/cpp/smi/LogDeterminantMutualInformation.cpp
+++ b/cpp/smi/LogDeterminantMutualInformation.cpp
@@ -49,6 +49,12 @@ LogDeterminantMutualInformation::LogDeterminantMutualInformation(ll n_, int numQ
     // std::cout << "Instantiated mutualInfo\n";
 }
 
+LogDeterminantMutualInformation::~LogDeterminantMutualInformation() {
+
+    delete mutualInfo;
+    delete logDet;
+}
+
 // LogDeterminantMutualInformation* LogDeterminantMutualInformation::clone() {
 //     return NULL;
 // }

--- a/cpp/smi/LogDeterminantMutualInformation.h
+++ b/cpp/smi/LogDeterminantMutualInformation.h
@@ -39,7 +39,7 @@ class LogDeterminantMutualInformation : public SetFunction {
     //                                             float epsilon, bool verbose, bool showProgress);
     void clearMemoization();
     void setMemoization(std::unordered_set<ll> const &X);
-    virtual ~logDeterminantMutualInformation();
+    virtual ~LogDeterminantMutualInformation();
     // LogDeterminantMutualInformation* clone();
 };
 #endif

--- a/cpp/smi/LogDeterminantMutualInformation.h
+++ b/cpp/smi/LogDeterminantMutualInformation.h
@@ -39,6 +39,7 @@ class LogDeterminantMutualInformation : public SetFunction {
     //                                             float epsilon, bool verbose, bool showProgress);
     void clearMemoization();
     void setMemoization(std::unordered_set<ll> const &X);
+    virtual ~logDeterminantMutualInformation();
     // LogDeterminantMutualInformation* clone();
 };
 #endif

--- a/cpp/smi/MutualInformation.cpp
+++ b/cpp/smi/MutualInformation.cpp
@@ -22,6 +22,11 @@ MutualInformation::MutualInformation(SetFunction& f_, std::unordered_set<ll> que
     fAUQ->setMemoization(querySet);
 }
 
+MutualInformation::~MutualInformation() {
+
+    delete fAUQ;
+}
+
 // MutualInformation* MutualInformation::clone() {
 //     return NULL;
 // }

--- a/cpp/smi/MutualInformation.h
+++ b/cpp/smi/MutualInformation.h
@@ -32,6 +32,7 @@ class MutualInformation : public SetFunction {
                                                 float epsilon, bool verbose, bool showProgress);
     void clearMemoization();
     void setMemoization(std::unordered_set<ll> const &X);
+    virtual ~MutualInformation();
     // MutualInformation* clone();
 };
 


### PR DESCRIPTION
Added destructors for LogDetMI C++ code. There is currently an issue where instantiating LogDetMI on the C++ side is dynamically allocating new memory but is not freeing it once the lifetime of those objects end. Repeatedly calling LogDetMI eventually causes out-of-memory issues. Here, I've added a fix that simply adds the destructors that free this memory.